### PR TITLE
make compatible with node.js v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colors": "^1.1.2",
     "debounce": "^1.0.0",
     "glob": "^6.0.1",
-    "node-watch": "^0.3.4",
+    "node-watch": "^0.7.0",
     "shelljs": "^0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
dependency node-watch crashes in node.js v14, as explained in yuanchuan/node-watch#94

Error is:

> TypeError [ERR_FEATURE_UNAVAILABLE_ON_PLATFORM]: The feature watch recursively is unavailable on the current platform, which is being used to run Node.js

This commit updates the dependency node-watch to fix the problem.